### PR TITLE
typing.Union raises RecursionError when comparing Union to other type

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -217,6 +217,9 @@ class UnionTests(BaseTestCase):
         self.assertNotEqual(u2, Any)
         self.assertNotEqual(u3, Any)
 
+    def test_union_compare_other(self):
+        self.assertNotEqual(Union, object)
+
     def test_union_object(self):
         u = Union[object]
         self.assertEqual(u, object)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -757,7 +757,7 @@ class _Union(_FinalTypingBase, _root=True):
 
     def __eq__(self, other):
         if not isinstance(other, _Union):
-            return self._subs_tree() == other
+            return self._subs_tree() is not self and self._subs_tree() == other
         return self.__tree_hash__ == other.__tree_hash__
 
     def __hash__(self):


### PR DESCRIPTION
Link to [cpython patch](http://bugs.python.org/issue29246)
