### PR TITLE
Typo in footnote

### DIFF
--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -746,6 +746,6 @@ message objects.
 
 .. rubric:: Footnotes
 
-.. [1] Oringally added in 3.4 as a :term:`provisional module <provisional
+.. [1] Originally added in 3.4 as a :term:`provisional module <provisional
        package>`.  Docs for legacy message class moved to
        :ref:`compat32_message`.


### PR DESCRIPTION
'Oringally' changed to 'Originally'

## CPython Mirror

https://github.com/python/cpython is a cpython mirror repository. Pull requests
are not accepted on this repo and will be automatically closed.

### Submit patches at https://bugs.python.org

For additional information about contributing to CPython, see the
[developer's guide](https://docs.python.org/devguide/#contributing).
